### PR TITLE
chown files to root inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN install-php-extensions \
 
 COPY --from=wordpress /usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/
 COPY --from=wordpress /usr/local/bin/docker-entrypoint.sh /usr/local/bin/
-COPY --from=wordpress --chown=www-data:www-data /usr/src/wordpress /app/public
+COPY --from=wordpress --chown=root:root /usr/src/wordpress /app/public
 
 VOLUME /var/www/html
 


### PR DESCRIPTION
FrankenPHP seems to run as `root` inside the container, but files are chowned to `www-data:www-data`. This makes it impossible to install new plugins via "Plugins > Add new" in the admin since WP is a bit finicky and wants the files to not only be writable by the web server process but also be owned by it. 