### PR TITLE
Fix volume path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN install-php-extensions \
 
 COPY --from=wordpress /usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/
 COPY --from=wordpress /usr/local/bin/docker-entrypoint.sh /usr/local/bin/
-COPY --from=wordpress --chown=www-data:www-data /usr/src/wordpress /app/public
+COPY --from=wordpress --chown=root:root /usr/src/wordpress /app/public
 COPY /app/public/wp-config-docker.php /app/public/wp-config.php
 
-VOLUME /var/www/html
+VOLUME /app/public
 
 RUN sed -i 's/php-fpm/frankenphp run/g' /usr/local/bin/docker-entrypoint.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       WORDPRESS_DB_PASSWORD: examplepass
       WORDPRESS_DB_NAME: exampledb
     volumes:
-      - wordpress:/var/www/html
+      - wordpress:/app/public
 
   db:
     image: mysql


### PR DESCRIPTION
use app directory for the volume
without this change, the wp instance wasn't persisted (themes, plugins uploads ...)

( also add the fix for the ownership of the files, https://github.com/dunglas/frankenphp-wordpress/pull/1 )