### PR TITLE
fix: Caddyfile changed location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ RUN sed -i \
     /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-CMD ["frankenphp", "run", "--config", "/etc/Caddyfile"]
+CMD ["frankenphp", "run", "--config", "/etc/caddy/Caddyfile"]


### PR DESCRIPTION
Apparently, the location of the configuration changed. Caddy weren't able to find the configuration file.
It has been relocated inside a "caddy" folder. This fix makes it work for me!

By the way, amazing performances results!