### PR TITLE
Can't update/install plugins - Run frankenphp as user www-data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,18 @@ COPY --from=wordpress --chown=root:root /usr/src/wordpress /usr/src/wordpress
 WORKDIR /var/www/html
 VOLUME /var/www/html
 
+ARG USER=www-data
+RUN chown -R ${USER}:${USER} /data/caddy && chown -R ${USER}:${USER} /config/caddy
+
 RUN sed -i \
-    -e 's/\[ "$1" = '\''php-fpm'\'' \]/\[\[ "$1" == su* \]\]/g' \
-    -e 's/php-fpm/su/g' \
+    -e 's/\[ "$1" = '\''php-fpm'\'' \]/\[\[ "$1" == frankenphp* \]\]/g' \
+    -e 's/php-fpm/frankenphp/g' \
     /usr/local/bin/docker-entrypoint.sh
 
 RUN sed -i \
     -e 's#root \* public/#root \* /var/www/html/#g' \
     /etc/caddy/Caddyfile
 
-RUN echo "frankenphp run --config /etc/caddy/Caddyfile" > /start.sh; \
-    chown -R www-data:www-data /data/caddy
-
+USER ${USER}
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-CMD ["su", "-s", "/bin/sh", "www-data", "/start.sh"]
+CMD ["frankenphp", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,8 @@ RUN sed -i \
     -e 's#root \* public/#root \* /var/www/html/#g' \
     /etc/caddy/Caddyfile
 
+RUN echo "frankenphp run --config /etc/caddy/Caddyfile" > /start.sh; \
+    chown -R www-data:www-data /data/caddy
+
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-CMD ["frankenphp", "run", "--config", "/etc/caddy/Caddyfile"]
+CMD ["su", "-s", "/bin/sh", "www-data", "/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ WORKDIR /var/www/html
 VOLUME /var/www/html
 
 RUN sed -i \
-    -e 's/\[ "$1" = '\''php-fpm'\'' \]/\[\[ "$1" == frankenphp* \]\]/g' \
-    -e 's/php-fpm/frankenphp/g' \
+    -e 's/\[ "$1" = '\''php-fpm'\'' \]/\[\[ "$1" == su* \]\]/g' \
+    -e 's/php-fpm/su/g' \
     /usr/local/bin/docker-entrypoint.sh
 
 RUN sed -i \


### PR DESCRIPTION
I tried this docker template and I noticed that wordpress cannot update itself or plugins/themes because of directory ownershsip issues.
Everything is owned by www-data but frankenphp runs as root.
I modified the dockerfile to run franken as www-data and it works now.
I also had to change the owner of `/data/caddy`. 
Is there any other folder I need to change the owner of ?
Do you know any better way to do this ?